### PR TITLE
Try keepalive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    command: gunicorn day_trader.wsgi -b 0:41000 --reload
+    command: gunicorn day_trader.wsgi -b 0:41000 --workers=4 --keep-alive=10 --reload
     container_name: day_trader_web
     environment:
      PYTHONUNBUFFERED: 1

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -14,7 +14,7 @@ http {
  server {
     listen 80;
     location / {
-       keepalive_requests 1000;
+       keepalive_requests 50000;
        keepalive_timeout 60;
        proxy_http_version 1.1;
        proxy_set_header Connection "";

--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -2,6 +2,7 @@ events { worker_connections 1024; }
 
 http {
  upstream day_trader {
+    keepalive 10;
     # These are our docker containers of the day_trader app
     server day_trader_web:41000;
 
@@ -13,6 +14,10 @@ http {
  server {
     listen 80;
     location / {
+       keepalive_requests 1000;
+       keepalive_timeout 60;
+       proxy_http_version 1.1;
+       proxy_set_header Connection "";
        proxy_pass http://day_trader;
        proxy_set_header Host $host;
     }

--- a/workload_generator/golang/docker-compose.yml
+++ b/workload_generator/golang/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   generator:
-    command: go run /service/workLoadGenerator.go -f="/service/workload_files/1userWorkLoad"
+    command: go run /service/workLoadGenerator.go -f="/service/workload_files/userWorkLoad"
     container_name: generator
     image: golang
     volumes:

--- a/workload_generator/golang/workLoadGenerator.go
+++ b/workload_generator/golang/workLoadGenerator.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -38,6 +40,7 @@ var amountCommands = map[string]int{
 var userMap = make(map[string][]*http.Request)
 var wg sync.WaitGroup
 var baseURL string
+var client = &http.Client{}
 
 func parseCommands(filename string) {
 	file, err := os.Open(filename)
@@ -119,13 +122,13 @@ func generateRequest(userID string, commands []string) *http.Request {
 }
 
 func makeRequest(requests []*http.Request) {
-	client := &http.Client{}
 	for _, req := range requests {
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Println("ERROR: ", err)
 		}
-		log.Println(resp)
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
 	}
 	wg.Done()
 }


### PR DESCRIPTION
This does 3 things:

1. Use a global client on golang generator side as well as read from response before closing.
2. Enable nginx keepalive between client(generator) and server(gunicorn)
3. Enable keepalive on gunicorn and increase workers to 4.