### PR TITLE
Cache stock and balances before committing

### DIFF
--- a/golang/day_trader/src/cache.go
+++ b/golang/day_trader/src/cache.go
@@ -45,5 +45,8 @@ func getCacheUser(key string) (*User, error) {
 		return user, err
 	}
 	err = user.UnmarshalJSON(item.Value)
+	if user.StockMap == nil {
+		user.StockMap = make(map[string]int)
+	}
 	return user, err
 }

--- a/golang/day_trader/src/db.go
+++ b/golang/day_trader/src/db.go
@@ -55,7 +55,7 @@ var createTableStatements = []string{
 	`CREATE TABLE IF NOT EXISTS User_Stock(
 		UserId varchar(32) NOT NULL,
 		StockSymbol varchar(3) NULL,
-		Amount INT DEFAULT 0,
+		Amount INT UNSIGNED DEFAULT 0,
 		UNIQUE(UserId, StockSymbol),
 		FOREIGN KEY (UserId) REFERENCES User(Id) ON DELETE CASCADE
 	)`,

--- a/golang/day_trader/src/main.go
+++ b/golang/day_trader/src/main.go
@@ -32,6 +32,7 @@ type User struct {
 	Id        string
 	BuyStack  []*Buy
 	SellStack []*Sell
+	StockMap  map[string]int
 }
 
 //easyjson:json
@@ -98,13 +99,13 @@ func (s *server) CreateUser(ctx context.Context, req *pb.Command) (*pb.Response,
 
 func (s *server) Add(ctx context.Context, req *pb.Command) (*pb.Response, error) {
 	user := getUser(req.UserId)
-	user.updateUserBalance(ctx, req.Amount)
+	user.updateUserBalance(ctx, req.Amount, true)
 	return &pb.Response{Message: user.toString()}, nil
 }
 
 func (s *server) Buy(ctx context.Context, req *pb.Command) (*pb.Response, error) {
 	user := getUser(req.UserId)
-	buy, err := createBuy(ctx, req.Amount, req.Symbol, user.Id)
+	buy, err := createBuy(ctx, req.Amount, req.Symbol, user)
 	return &pb.Response{Message: buy.toString()}, err
 }
 
@@ -118,7 +119,7 @@ func (s *server) Quote(ctx context.Context, req *pb.Command) (*pb.Response, erro
 
 func (s *server) Sell(ctx context.Context, req *pb.Command) (*pb.Response, error) {
 	user := getUser(req.UserId)
-	sell, err := createSell(ctx, req.Amount, req.Symbol, user.Id)
+	sell, err := createSell(ctx, req.Amount, req.Symbol, user)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (s *server) CommitBuy(ctx context.Context, req *pb.Command) (*pb.Response, 
 	if buy == nil {
 		return nil, errors.New("No buy on the stack")
 	}
-	userStock, err := buy.commit(ctx, false)
+	userStock, err := buy.commit(ctx, user, false)
 	return &pb.Response{Message: userStock.toString()}, err
 }
 func (s *server) CommitSell(ctx context.Context, req *pb.Command) (*pb.Response, error) {
@@ -142,7 +143,7 @@ func (s *server) CommitSell(ctx context.Context, req *pb.Command) (*pb.Response,
 	if sell == nil {
 		return nil, errors.New("No sell on the stack")
 	}
-	err := sell.commit(ctx, false)
+	err := sell.commit(ctx, false, user)
 	return &pb.Response{Message: user.toString()}, err
 }
 
@@ -150,7 +151,7 @@ func (s *server) CancelBuy(ctx context.Context, req *pb.Command) (*pb.Response, 
 	user := getUser(req.UserId)
 	buy := user.popFromBuyStack()
 	if buy != nil {
-		buy.cancel(ctx)
+		buy.cancel(ctx, user)
 	} else {
 		return nil, errors.New("No buy on stack")
 	}
@@ -161,7 +162,7 @@ func (s *server) CancelSell(ctx context.Context, req *pb.Command) (*pb.Response,
 	user := getUser(req.UserId)
 	sell := user.popFromSellStack()
 	if sell != nil {
-		sell.cancel(ctx)
+		sell.cancel(ctx, user)
 	} else {
 		return nil, errors.New("No sell on stack")
 	}
@@ -175,7 +176,7 @@ func (s *server) SetBuyAmount(ctx context.Context, req *pb.Command) (*pb.Respons
 	}
 	trigger, err := getBuyTrigger(ctx, user.Id, req.Symbol)
 	if err != nil {
-		buy, err := createBuy(ctx, req.Amount, req.Symbol, user.Id)
+		buy, err := createBuy(ctx, req.Amount, req.Symbol, user)
 		if err != nil {
 			return nil, err
 		}
@@ -186,14 +187,16 @@ func (s *server) SetBuyAmount(ctx context.Context, req *pb.Command) (*pb.Respons
 		trigger := createBuyTrigger(ctx, user.Id, req.Symbol, buy.Id, req.Amount)
 		return &pb.Response{Message: trigger.toString()}, nil
 	}
-	return &pb.Response{Message: trigger.toString()}, trigger.updateCashAmount(ctx, req.Amount)
+	return &pb.Response{Message: trigger.toString()}, trigger.updateCashAmount(ctx, req.Amount, user)
 }
 
 func (s *server) SetSellAmount(ctx context.Context, req *pb.Command) (*pb.Response, error) {
+	user := getUser(userId)
 	trigger, err := getSellTrigger(ctx, req.UserId, req.Symbol)
 	if err != nil {
+		user := getUser(req.UserId)
 		sell := &Sell{StockSymbol: req.Symbol, UserId: req.UserId}
-		err = sell.updateCashAmount(ctx, req.Amount)
+		err = sell.updateCashAmount(ctx, req.Amount, user)
 		if err != nil {
 			return nil, err
 		}
@@ -201,7 +204,7 @@ func (s *server) SetSellAmount(ctx context.Context, req *pb.Command) (*pb.Respon
 		trigger := createSellTrigger(ctx, req.UserId, req.Symbol, sell.Id, req.Amount)
 		return &pb.Response{Message: trigger.toString()}, nil
 	}
-	return &pb.Response{Message: trigger.toString()}, trigger.updateCashAmount(ctx, req.Amount)
+	return &pb.Response{Message: trigger.toString()}, trigger.updateCashAmount(ctx, req.Amount, user)
 }
 
 func (s *server) SetBuyTrigger(ctx context.Context, req *pb.Command) (*pb.Response, error) {
@@ -214,29 +217,32 @@ func (s *server) SetBuyTrigger(ctx context.Context, req *pb.Command) (*pb.Respon
 }
 
 func (s *server) SetSellTrigger(ctx context.Context, req *pb.Command) (*pb.Response, error) {
+	user := getUser(req.UserId)
 	trigger, err := getSellTrigger(ctx, req.UserId, req.Symbol)
 	if err != nil {
 		return nil, errors.New("Trigger requires a sell amount first, please make one")
 	}
-	trigger.updatePrice(ctx, req.Amount)
+	trigger.updatePrice(ctx, req.Amount, user)
 	return &pb.Response{Message: trigger.toString()}, nil
 }
 
 func (s *server) CancelSetBuy(ctx context.Context, req *pb.Command) (*pb.Response, error) {
+	user := getUser(userId)
 	trigger, err := getBuyTrigger(ctx, req.UserId, req.Symbol)
 	if err != nil {
 		return nil, errors.New("Set buy not found")
 	}
-	trigger.cancel(ctx)
+	trigger.cancel(ctx, user)
 	return &pb.Response{Message: "Disabling trigger"}, nil
 }
 
 func (s *server) CancelSetSell(ctx context.Context, req *pb.Command) (*pb.Response, error) {
+	user := getUser(userId)
 	trigger, err := getSellTrigger(ctx, req.UserId, req.Symbol)
 	if err != nil {
 		return nil, errors.New("Set sell not found")
 	}
-	trigger.cancel(ctx)
+	trigger.cancel(ctx, user)
 	return &pb.Response{Message: "Disabling trigger"}, nil
 }
 

--- a/golang/day_trader/src/main_easyjson.go
+++ b/golang/day_trader/src/main_easyjson.go
@@ -258,6 +258,26 @@ func easyjson89aae3efDecodeDayTrader2(in *jlexer.Lexer, out *User) {
 				}
 				in.Delim(']')
 			}
+		case "StockMap":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.StockMap = make(map[string]int)
+				} else {
+					out.StockMap = nil
+				}
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v3 int
+					v3 = int(in.Int())
+					(out.StockMap)[key] = v3
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -314,14 +334,14 @@ func easyjson89aae3efEncodeDayTrader2(out *jwriter.Writer, in User) {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v3, v4 := range in.BuyStack {
-				if v3 > 0 {
+			for v4, v5 := range in.BuyStack {
+				if v4 > 0 {
 					out.RawByte(',')
 				}
-				if v4 == nil {
+				if v5 == nil {
 					out.RawString("null")
 				} else {
-					(*v4).MarshalEasyJSON(out)
+					(*v5).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -339,17 +359,43 @@ func easyjson89aae3efEncodeDayTrader2(out *jwriter.Writer, in User) {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v5, v6 := range in.SellStack {
-				if v5 > 0 {
+			for v6, v7 := range in.SellStack {
+				if v6 > 0 {
 					out.RawByte(',')
 				}
-				if v6 == nil {
+				if v7 == nil {
 					out.RawString("null")
 				} else {
-					(*v6).MarshalEasyJSON(out)
+					(*v7).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"StockMap\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		if in.StockMap == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+			out.RawString(`null`)
+		} else {
+			out.RawByte('{')
+			v8First := true
+			for v8Name, v8Value := range in.StockMap {
+				if v8First {
+					v8First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v8Name))
+				out.RawByte(':')
+				out.Int(int(v8Value))
+			}
+			out.RawByte('}')
 		}
 	}
 	out.RawByte('}')

--- a/golang/day_trader/src/user.go
+++ b/golang/day_trader/src/user.go
@@ -39,6 +39,7 @@ func getUser(userID string) *User {
 		db.QueryRow("SELECT Balance from User where Id=?", user.Id).Scan(&user.Balance)
 		user.SellStack = make([]*Sell, 0)
 		user.BuyStack = make([]*Buy, 0)
+		user.StockMap = make(map[string]int)
 		user.setCache()
 	}
 	return user
@@ -48,12 +49,13 @@ func createUser(userID string) error {
 	user := &User{Id: userID, Balance: 0, Name: ""}
 	user.SellStack = make([]*Sell, 0)
 	user.BuyStack = make([]*Buy, 0)
+	user.StockMap = make(map[string]int)
 	user.setCache()
 	_, err := db.Exec("insert into User(Id) values(?)", userID)
 	return err
 }
 
-func (user *User) updateUserBalance(ctx context.Context, amount float32) (*User, error) {
+func (user *User) updateUserBalance(ctx context.Context, amount float32, writeThrough bool) (*User, error) {
 	var accountAction string
 	if amount < 0 {
 		accountAction = "Remove"
@@ -61,9 +63,11 @@ func (user *User) updateUserBalance(ctx context.Context, amount float32) (*User,
 		accountAction = "Add"
 	}
 	user.Balance += amount
-	_, err := db.Exec("update User set Balance=? where Id=?", user.Balance, user.Id)
-	if err != nil {
-		return user, err
+	if writeThrough {
+		_, err := db.Exec("update User set Balance=? where Id=?", user.Balance, user.Id)
+		if err != nil {
+			return user, err
+		}
 	}
 	pbLog, err := makeLogFromContext(ctx)
 	if err != nil {
@@ -75,4 +79,13 @@ func (user *User) updateUserBalance(ctx context.Context, amount float32) (*User,
 	logChan <- logEvent
 	user.setCache()
 	return user, nil
+}
+
+func (user *User) updateStockBalance(ctx context.Context, symbol string) error {
+	amount := user.StockMap[symbol]
+	_, err := db.Exec("insert into User_Stock(UserId,StockSymbol,Amount) Values(?,?,?) on duplicate key update Amount=?", user.Id, symbol, amount, amount)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/golang/logging/src/main.go
+++ b/golang/logging/src/main.go
@@ -109,6 +109,10 @@ func (s *server) LogDebugEvent(ctx context.Context, req *pb.Log) (*pb.Response, 
 	return &pb.Response{Message: strconv.Itoa(baseLogID)}, err
 }
 
+func (s *server) DumpLogs(ctx context.Context, req *pb.Command) (*pb.Response, error) {
+	return &pb.Response{Message: "yee dump"}, nil
+}
+
 func startGRPCServer() {
 	lis, err := net.Listen("tcp", grpcPort)
 	if err != nil {


### PR DESCRIPTION
What this pr does:

1. Caches the changes to buy/sells. Ie if a user completes a buy, it doesn't update the balance in the DB until the user actually commits the buy. Vice versa, when a user sells, it doesn't update the stock info in the DB untill the commit happens.

2. Changes the workflow so the getUser() command is always called within the main function and the pointer to the user is passed around from there. This avoids any issues of stale users when cache updates happens.

- [x] Tested